### PR TITLE
기본과제 - 동시성 제어

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
+	implementation("org.springframework.retry:spring-retry")
 
     // DB
 	runtimeOnly("com.mysql:mysql-connector-j")

--- a/src/main/java/kr/hhplus/be/server/domain/balance/UserBalance.java
+++ b/src/main/java/kr/hhplus/be/server/domain/balance/UserBalance.java
@@ -27,6 +27,9 @@ public class UserBalance extends BaseEntity {
 
     private long balance;
 
+    @Version
+    private Integer version;
+
     @Builder
     private UserBalance(Long id, User user, long balance) {
         this.id = id;

--- a/src/main/java/kr/hhplus/be/server/domain/balance/UserBalanceService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/balance/UserBalanceService.java
@@ -30,6 +30,11 @@ public class UserBalanceService {
         return UserBalanceInfo.from(userBalance);
     }
 
+    @Retryable(
+            value = ObjectOptimisticLockingFailureException.class, // 재시도 대상
+            maxAttempts = 2,                          // 최대 재시도 횟수 (기본값 3)
+            backoff = @Backoff(delay = 1000)        // 재시도 간격 0.5초 (기본값 1초)
+    )
     @Transactional
     public UserBalanceInfo charge(UserBalanceCommand.Charge command) {
         UserBalance userBalance = userBalanceRepository.getByUserId(command.getUserId());

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/Coupon.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/Coupon.java
@@ -89,4 +89,8 @@ public class Coupon extends BaseEntity {
     public void soldOut() {
         this.couponStatus = CouponStatus.SOLD_OUT;
     }
+
+    public void updateIssuedQuantity(int quantity) {
+        this.issuedQuantity += quantity;
+    }
 }

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/CouponRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/CouponRepository.java
@@ -1,9 +1,12 @@
 package kr.hhplus.be.server.domain.coupon;
 
+import java.util.Optional;
+
 public interface CouponRepository {
 
     Coupon save(Coupon coupon);
 
-    Coupon getById(Long couponId);
+    Coupon getById(Long Id);
 
+    Optional<Coupon> findByIdForUpdate(Long Id);
 }

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/CouponService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/CouponService.java
@@ -1,5 +1,7 @@
 package kr.hhplus.be.server.domain.coupon;
 
+import kr.hhplus.be.server.support.exception.ApiErrorCode;
+import kr.hhplus.be.server.support.exception.ApiException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,7 +16,8 @@ public class CouponService {
 
     @Transactional
     public CouponInfo issueCoupon(CouponCommand command) {
-        Coupon coupon = couponRepository.getById(command.couponId());
+        Coupon coupon = couponRepository.findByIdForUpdate(command.couponId())
+                .orElseThrow(() -> new ApiException(ApiErrorCode.NOT_FOUND_COUPON));
 
         Coupon issuedCoupon = coupon.issue();
         couponRepository.save(issuedCoupon);

--- a/src/main/java/kr/hhplus/be/server/domain/product/ProductRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/product/ProductRepository.java
@@ -1,9 +1,13 @@
 package kr.hhplus.be.server.domain.product;
 
+import java.util.Optional;
+
 public interface ProductRepository {
+
+    Product save(Product product);
 
     Product getById(Long id);
 
-    Product save(Product product);
+    Optional<Product> findByIdForUpdate(Long id);
 
 }

--- a/src/main/java/kr/hhplus/be/server/domain/product/ProductService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/product/ProductService.java
@@ -1,6 +1,8 @@
 package kr.hhplus.be.server.domain.product;
 
 import kr.hhplus.be.server.domain.order.OrderCommand;
+import kr.hhplus.be.server.support.exception.ApiErrorCode;
+import kr.hhplus.be.server.support.exception.ApiException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,7 +32,8 @@ public class ProductService {
     public void validateAndSubStockProducts(List<OrderCommand.CreateOrderItem> createOrderItems) {
         for (OrderCommand.CreateOrderItem orderItem : createOrderItems) {
             // 상품을 조회
-            Product product = productRepository.getById(orderItem.getProductId());
+            Product product = productRepository.findByIdForUpdate(orderItem.getProductId())
+                    .orElseThrow(() -> new ApiException(ApiErrorCode.NOT_FOUND_PRODUCT));
 
             // 재고 차감
             product.subStock(orderItem.getQuantity());

--- a/src/main/java/kr/hhplus/be/server/infra/coupon/CouponJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infra/coupon/CouponJpaRepository.java
@@ -1,8 +1,17 @@
 package kr.hhplus.be.server.infra.coupon;
 
+import jakarta.persistence.LockModeType;
 import kr.hhplus.be.server.domain.coupon.Coupon;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface CouponJpaRepository extends JpaRepository<Coupon, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select c from Coupon c where c.id = :id")
+    Optional<Coupon> findByIdForUpdate(Long id);
 
 }

--- a/src/main/java/kr/hhplus/be/server/infra/coupon/CouponRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infra/coupon/CouponRepositoryImpl.java
@@ -6,6 +6,8 @@ import kr.hhplus.be.server.support.exception.ApiErrorCode;
 import kr.hhplus.be.server.support.exception.ApiException;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public class CouponRepositoryImpl implements CouponRepository {
 
@@ -24,5 +26,10 @@ public class CouponRepositoryImpl implements CouponRepository {
     public Coupon getById(Long couponId) {
         return couponJpaRepository.findById(couponId)
                 .orElseThrow(() -> new ApiException(ApiErrorCode.NOT_FOUND_COUPON));
+    }
+
+    @Override
+    public Optional<Coupon> findByIdForUpdate(Long id) {
+        return couponJpaRepository.findByIdForUpdate(id);
     }
 }

--- a/src/main/java/kr/hhplus/be/server/infra/product/ProductJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infra/product/ProductJpaRepository.java
@@ -1,7 +1,16 @@
 package kr.hhplus.be.server.infra.product;
 
+import jakarta.persistence.LockModeType;
 import kr.hhplus.be.server.domain.product.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface ProductJpaRepository extends JpaRepository<Product, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select p from Product p where p.id = :id")
+    Optional<Product> findByIdForUpdate(Long id);
 }

--- a/src/main/java/kr/hhplus/be/server/infra/product/ProductRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infra/product/ProductRepositoryImpl.java
@@ -6,6 +6,8 @@ import kr.hhplus.be.server.support.exception.ApiErrorCode;
 import kr.hhplus.be.server.support.exception.ApiException;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public class ProductRepositoryImpl implements ProductRepository {
 
@@ -16,13 +18,18 @@ public class ProductRepositoryImpl implements ProductRepository {
     }
 
     @Override
+    public Product save(Product product) {
+        return productJpaRepository.save(product);
+    }
+
+    @Override
     public Product getById(Long id) {
         return productJpaRepository.findById(id)
                 .orElseThrow(() -> new ApiException(ApiErrorCode.NOT_FOUND_PRODUCT));
     }
 
     @Override
-    public Product save(Product product) {
-        return productJpaRepository.save(product);
+    public Optional<Product> findByIdForUpdate(Long id) {
+        return productJpaRepository.findByIdForUpdate(id);
     }
 }

--- a/src/main/java/kr/hhplus/be/server/support/concurrent/ConcurrentTestExecutor.java
+++ b/src/main/java/kr/hhplus/be/server/support/concurrent/ConcurrentTestExecutor.java
@@ -1,0 +1,47 @@
+package kr.hhplus.be.server.support.concurrent;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ConcurrentTestExecutor {
+
+    public ConcurrentTestResult execute(int threads, int counter, List<Runnable> tasks) throws Throwable {
+        ExecutorService executorService = Executors.newFixedThreadPool(threads);
+        CountDownLatch latch = new CountDownLatch(counter);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failureCount = new AtomicInteger();
+
+        // 예외를 보관할 리스트
+        CopyOnWriteArrayList<Throwable> errors = new CopyOnWriteArrayList<>();
+
+        for (int i = 0; i < counter; i++) {
+            for (Runnable task : tasks) {
+                executorService.execute(() -> {
+                    try {
+                        task.run();
+                        successCount.incrementAndGet();
+                    } catch (Throwable t) {
+                        failureCount.incrementAndGet();
+                        errors.add(t);
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        if (!errors.isEmpty()) {
+            throw errors.get(0);
+        }
+
+        return ConcurrentTestResult.of(successCount, failureCount);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/support/concurrent/ConcurrentTestResult.java
+++ b/src/main/java/kr/hhplus/be/server/support/concurrent/ConcurrentTestResult.java
@@ -1,0 +1,24 @@
+package kr.hhplus.be.server.support.concurrent;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ConcurrentTestResult {
+
+    private AtomicInteger successCount;
+    private AtomicInteger failureCount;
+
+    private ConcurrentTestResult(AtomicInteger successCount, AtomicInteger failureCount) {
+        this.successCount = successCount;
+        this.failureCount = failureCount;
+    }
+
+    public static ConcurrentTestResult of(AtomicInteger successCount, AtomicInteger failureCount) {
+        return new ConcurrentTestResult(successCount, failureCount);
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/concurrency/CouponConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/concurrency/CouponConcurrencyTest.java
@@ -1,0 +1,99 @@
+package kr.hhplus.be.server.concurrency;
+
+import kr.hhplus.be.server.domain.coupon.*;
+import kr.hhplus.be.server.domain.user.User;
+import kr.hhplus.be.server.domain.user.UserRepository;
+import kr.hhplus.be.server.support.concurrent.ConcurrentTestResult;
+import kr.hhplus.be.server.support.concurrent.ConcurrentTestExecutor;
+import kr.hhplus.be.server.support.exception.ApiErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+class CouponConcurrencyTest {
+
+    @Autowired
+    private CouponService couponService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    private ConcurrentTestExecutor executor;
+
+    private User user;
+    private Coupon coupon;
+
+    @BeforeEach
+    void setUp() {
+        user = userRepository.save(User.create("닉네임1"));
+        coupon = couponRepository.save(Coupon.create("test123", DiscountType.PERCENTAGE, 10, 300, CouponStatus.ACTIVE, LocalDateTime.now().plusDays(1)));
+        executor = new ConcurrentTestExecutor();
+    }
+
+    @Test
+    void 선착순_쿠폰_발급_성공_동시성_300명_테스트() throws Throwable {
+        // given
+        CouponCommand command = CouponCommand.of(coupon.getId());
+
+        List<Runnable> tasks = List.of(() -> couponService.issueCoupon(command));
+
+        // when
+        ConcurrentTestResult executed = executor.execute(300, 300, tasks);
+
+        // then
+        System.out.println("성공 카운트: " + executed.getSuccessCount().get());
+        System.out.println("실패 카운트: " + executed.getFailureCount().get());
+
+        Coupon result = couponRepository.getById(coupon.getId());
+        assertThat(result.getIssuedQuantity()).isEqualTo(300);
+        assertThat(result.getCouponStatus()).isEqualTo(CouponStatus.SOLD_OUT);
+    }
+
+    @Test
+    void 선착순_쿠폰_발급_초과로_실패_동시성_301명_테스트() throws Throwable {
+        // given
+        CouponCommand command = CouponCommand.of(coupon.getId());
+
+        List<Runnable> tasks = List.of(() -> couponService.issueCoupon(command));
+
+        // when & then
+        assertThatThrownBy(() -> executor.execute(301, 301, tasks))
+                .hasMessage(ApiErrorCode.COUPON_NOT_AVAILABLE_TO_ISSUE.getMessage());
+    }
+
+    @Test
+    void 선착순_쿠폰_발급_일부_성공_일부_실패() throws Throwable {
+        // given: 이미 280개 발급된 쿠폰
+        coupon.updateIssuedQuantity(280);
+        couponRepository.save(coupon);
+        CouponCommand command = CouponCommand.of(coupon.getId());
+        List<Runnable> tasks = List.of(() -> couponService.issueCoupon(command));
+
+        // when
+        ConcurrentTestResult executed = executor.executeIgnoreErrors(300, 300, tasks);
+
+        // then
+        System.out.println("성공 카운트: " + executed.getSuccessCount().get());
+        System.out.println("실패 카운트: " + executed.getFailureCount().get());
+
+        // 20명만 성공, 나머지 280명은 실패
+        assertThat(executed.getSuccessCount().get()).isEqualTo(20);
+        assertThat(executed.getFailureCount().get()).isEqualTo(280);
+
+        // 총 300개 발급, 상태는 SOLD_OUT
+        Coupon result = couponRepository.getById(coupon.getId());
+        assertThat(result.getIssuedQuantity()).isEqualTo(300);
+        assertThat(result.getCouponStatus()).isEqualTo(CouponStatus.SOLD_OUT);
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/concurrency/ProductConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/concurrency/ProductConcurrencyTest.java
@@ -1,0 +1,73 @@
+package kr.hhplus.be.server.concurrency;
+
+import kr.hhplus.be.server.domain.order.OrderCommand;
+import kr.hhplus.be.server.domain.product.Category;
+import kr.hhplus.be.server.domain.product.Product;
+import kr.hhplus.be.server.domain.product.ProductRepository;
+import kr.hhplus.be.server.domain.product.ProductService;
+import kr.hhplus.be.server.support.concurrent.ConcurrentTestExecutor;
+import kr.hhplus.be.server.support.concurrent.ConcurrentTestResult;
+import kr.hhplus.be.server.support.exception.ApiErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+@SpringBootTest
+public class ProductConcurrencyTest {
+
+    @Autowired
+    private ProductService productService;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    private Product product;
+    private ConcurrentTestExecutor executor;
+
+    @BeforeEach
+    void setUp() {
+        product = productRepository.save(Product.create("맨투맨", 10000, 10, Category.TOP));
+        executor = new ConcurrentTestExecutor();
+    }
+
+    @Test
+    void 총_재고_10개일때_동시에_3명_재고_3개_차감_성공_잔여재고_1개() throws Throwable {
+        // given
+        OrderCommand.CreateOrderItem cmd1 = new OrderCommand.CreateOrderItem(product.getId(), 3, 10000);
+        List<OrderCommand.CreateOrderItem> cmds = List.of(cmd1);
+        List<Runnable> tasks = List.of(() -> productService.validateAndSubStockProducts(cmds));
+
+        // when
+        ConcurrentTestResult context = executor.execute(3, 3, tasks);
+
+        // then
+        System.out.println("성공 카운트: " + context.getSuccessCount().get());
+        System.out.println("실패 카운트: " + context.getFailureCount().get());
+
+        Product result = productRepository.getById(product.getId());
+        System.out.println("남은 재고: " + result.getStockQuantity());
+        assertThat(result.getStockQuantity()).isEqualTo(1);
+    }
+
+    @Test
+    void 총_재고_10개일때_동시에_4명_재고_3개_차감_실패_재고부족발생() throws Throwable {
+        // given
+        OrderCommand.CreateOrderItem cmd1 = new OrderCommand.CreateOrderItem(product.getId(), 3, 10000);
+        List<OrderCommand.CreateOrderItem> cmds = List.of(cmd1);
+        List<Runnable> tasks = List.of(() -> productService.validateAndSubStockProducts(cmds));
+
+        // when & then
+        assertThatThrownBy(() -> executor.execute(4, 4, tasks))
+                .hasMessage(ApiErrorCode.INSUFFICIENT_STOCK.getMessage());
+
+        Product result = productRepository.getById(product.getId());
+        System.out.println("남은 재고: " + result.getStockQuantity());
+        assertThat(result.getStockQuantity()).isEqualTo(1);
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/concurrency/UserBalanceConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/concurrency/UserBalanceConcurrencyTest.java
@@ -47,11 +47,11 @@ class UserBalanceConcurrencyTest {
         List<Runnable> tasks = List.of(() -> userBalanceService.charge(cmd));
 
         // when
-        ConcurrentTestResult context = executor.execute(2, 2, tasks);
+        ConcurrentTestResult executed = executor.execute(2, 2, tasks);
 
         // then
-        System.out.println("성공 카운트: " + context.getSuccessCount().get());
-        System.out.println("실패 카운트: " + context.getFailureCount().get());
+        System.out.println("성공 카운트: " + executed.getSuccessCount().get());
+        System.out.println("실패 카운트: " + executed.getFailureCount().get());
 
         UserBalance userBalance = userBalanceRepository.getByUserId(user.getId());
         System.out.println("최종 유저 잔액: " + userBalance.getBalance());

--- a/src/test/java/kr/hhplus/be/server/concurrency/UserBalanceConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/concurrency/UserBalanceConcurrencyTest.java
@@ -1,0 +1,60 @@
+package kr.hhplus.be.server.concurrency;
+
+import kr.hhplus.be.server.domain.balance.UserBalance;
+import kr.hhplus.be.server.domain.balance.UserBalanceCommand;
+import kr.hhplus.be.server.domain.balance.UserBalanceRepository;
+import kr.hhplus.be.server.domain.balance.UserBalanceService;
+import kr.hhplus.be.server.domain.user.User;
+import kr.hhplus.be.server.domain.user.UserRepository;
+import kr.hhplus.be.server.support.concurrent.ConcurrentTestResult;
+import kr.hhplus.be.server.support.concurrent.ConcurrentTestExecutor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class UserBalanceConcurrencyTest {
+
+    @Autowired
+    private UserBalanceService userBalanceService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserBalanceRepository userBalanceRepository;
+
+    private User user;
+    private ConcurrentTestExecutor executor;
+
+    @BeforeEach
+    void setUp() {
+        user = userRepository.save(User.create("닉네임1"));
+        userBalanceRepository.save(UserBalance.create(user, 0));
+        executor = new ConcurrentTestExecutor();
+    }
+
+    @Test
+    void 유저_포인트_충전_2번_동시성_테스트() throws Throwable {
+        // given
+        UserBalanceCommand.Charge cmd = UserBalanceCommand.Charge.of(user.getId(), 1000);
+
+        List<Runnable> tasks = List.of(() -> userBalanceService.charge(cmd));
+
+        // when
+        ConcurrentTestResult context = executor.execute(2, 2, tasks);
+
+        // then
+        System.out.println("성공 카운트: " + context.getSuccessCount().get());
+        System.out.println("실패 카운트: " + context.getFailureCount().get());
+
+        UserBalance userBalance = userBalanceRepository.getByUserId(user.getId());
+        System.out.println("최종 유저 잔액: " + userBalance.getBalance());
+        assertThat(userBalance.getBalance()).isEqualTo(2000);
+    }
+}


### PR DESCRIPTION
### **커밋 링크**

📝 동시성 제어 보고서 https://gifted-watchmaker-a9f.notion.site/1de0b58dfe738020a537d58f94d553f3

동시성 제어 준비: c45aef266419679fddc0f36123303e6e96533999, 228685c80d833ac3365bc0bfaf61abe4eb82c0de, d53ddb375309383ce0ea384a902714cdde2ffebb

유저 잔액 낙관적 락 적용 : 23f1d23c853742f0afb5548d3219abb5820e1666
유저 잔액 동시성 테스트: 4ed00b242041ba1a2899df7bb7eef5f0ddf09e0e

선착순 쿠폰 발급 비관적 락 적용 : 50bdff572a3922fe2d8529fd65be46f5e080022b
선착순 쿠폰 발급 동시성 테스트: e496f5737c147c6505b2f6268a8ab5c3ff230155

재고 차감 비관적 락 적용 : d97e5d883398c46fdc865981076f4a7cc1938f68
재고 차감 동시성 테스트: b5ac0818b2974bd28705dde846cbc7a709ad0470

---
### **리뷰 포인트(질문)**
Q1. 낙관적 락, 비관적 락 정의에 대해서 
낙관적 락
- 실패해도 괜찮다
- 주로 본인꺼 조회/업데이트

비관적 락
- 실패하면 안된다
- 공유자원 조회/업데이트

라고 정의를 내렸는데 이렇게 생각해도될까요?

Q2. 통합테스트하는데 너무 오래걸리는데 더 빠르게 할 수 있는 방법이 있을까요?


<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)
  
  좋은 예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->
---
### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->
- 동시성 문제, 트랜잭션에 대해 생각을 많이 해본 점
### Problem
<!--개선이 필요한 점-->
- 너무 생각을 오래해서 과제시간이 적었다..
### Try
<!-- 새롭게 시도할 점 -->
- 분산락에 대해 공부하기