### PR TITLE
이벤트 클래스 리팩토링

### DIFF
--- a/src/main/java/kr/hhplus/be/server/application/order/OrderFacade.java
+++ b/src/main/java/kr/hhplus/be/server/application/order/OrderFacade.java
@@ -4,9 +4,9 @@ import kr.hhplus.be.server.application.payment.PaymentCriteria;
 import kr.hhplus.be.server.domain.balance.UserBalanceCommand;
 import kr.hhplus.be.server.domain.balance.UserBalanceService;
 import kr.hhplus.be.server.domain.order.OrderCommand;
-import kr.hhplus.be.server.domain.order.event.OrderEventPublisher;
 import kr.hhplus.be.server.domain.order.OrderInfo;
 import kr.hhplus.be.server.domain.order.OrderService;
+import kr.hhplus.be.server.domain.order.event.OrderEventPublisher;
 import kr.hhplus.be.server.domain.payment.PaymentService;
 import kr.hhplus.be.server.domain.product.ProductService;
 import org.springframework.stereotype.Component;
@@ -54,7 +54,7 @@ public class OrderFacade {
         OrderInfo confirmOrderInfo = orderService.confirmOrder(OrderCommand.Confirm.from(paymentCriteria.orderId()));
 
         // 주문 확정 이벤트
-        orderEventPublisher.publishOrderConfirmed(confirmOrderInfo);
+        orderEventPublisher.publishOrderConfirmedEvent(confirmOrderInfo);
 
         return OrderResult.from(confirmOrderInfo);
     }

--- a/src/main/java/kr/hhplus/be/server/application/order/event/OrderConfirmedEventListener.java
+++ b/src/main/java/kr/hhplus/be/server/application/order/event/OrderConfirmedEventListener.java
@@ -1,0 +1,51 @@
+package kr.hhplus.be.server.application.order.event;
+
+import kr.hhplus.be.server.application.order.port.OrderDataPlatformClient;
+import kr.hhplus.be.server.domain.order.event.OrderEvent;
+import kr.hhplus.be.server.domain.sales.ProductSalesService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+public class OrderConfirmedEventListener {
+
+    private final OrderDataPlatformClient orderDataPlatformClient;
+    private final ProductSalesService productSalesService;
+
+    public OrderConfirmedEventListener(OrderDataPlatformClient orderDataPlatformClient, ProductSalesService productSalesService) {
+        this.orderDataPlatformClient = orderDataPlatformClient;
+        this.productSalesService = productSalesService;
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void sendToDataPlatform(OrderEvent.Confirmed event) {
+        log.info("sendToDataPlatform 이벤트 실행");
+
+        try {
+            orderDataPlatformClient.sendOrderData(event.getOrderInfo());
+            log.info("데이터 플랫폼에 주문 데이터 전송 완료");
+
+        } catch (Exception e) {
+            log.info("데이터 플랫폼에 주문 데이터 전송 실패");
+        }
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void storeProductSalesToRedis(OrderEvent.Confirmed event) {
+        log.info("storeProductSalesToRedis 이벤트 실행");
+
+        try {
+            productSalesService.add(event.getOrderInfo().orderItems());
+            log.info("상품 판매량 기록 완료");
+
+        } catch (Exception e) {
+            log.info("상품 판매량 기록 실패");
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/application/order/event/OrderDataPlatformEventListener.java
+++ b/src/main/java/kr/hhplus/be/server/application/order/event/OrderDataPlatformEventListener.java
@@ -21,8 +21,12 @@ public class OrderDataPlatformEventListener {
     public void sendToDataPlatform(OrderConfirmedEvent event) {
         log.info("OrderDataPlatformEventListener 실행");
 
-        orderDataPlatformClient.sendOrderData(event.getOrderInfo());
+        try {
+            orderDataPlatformClient.sendOrderData(event.getOrderInfo());
+            log.info("데이터 플랫폼에 주문 데이터 전송 완료");
 
-        log.info("데이터 플랫폼에 주문 데이터 전송 완료");
+        } catch (Exception e) {
+            log.info("데이터 플랫폼에 주문 데이터 전송 실패");
+        }
     }
 }

--- a/src/main/java/kr/hhplus/be/server/domain/order/event/OrderEvent.java
+++ b/src/main/java/kr/hhplus/be/server/domain/order/event/OrderEvent.java
@@ -1,0 +1,17 @@
+package kr.hhplus.be.server.domain.order.event;
+
+import kr.hhplus.be.server.domain.order.OrderInfo;
+import lombok.Getter;
+
+public class OrderEvent {
+
+    @Getter
+    public static class Confirmed {
+
+        private final OrderInfo orderInfo;
+
+        public Confirmed(OrderInfo orderInfo) {
+            this.orderInfo = orderInfo;
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/order/event/OrderEventPublisher.java
+++ b/src/main/java/kr/hhplus/be/server/domain/order/event/OrderEventPublisher.java
@@ -5,5 +5,7 @@ import kr.hhplus.be.server.domain.order.OrderInfo;
 public interface OrderEventPublisher {
 
     void publishOrderConfirmed(OrderInfo orderInfo);
+
+    void publishOrderConfirmedEvent(OrderInfo orderInfo);
 }
 

--- a/src/main/java/kr/hhplus/be/server/infra/order/OrderEventSpringPublisher.java
+++ b/src/main/java/kr/hhplus/be/server/infra/order/OrderEventSpringPublisher.java
@@ -1,8 +1,9 @@
 package kr.hhplus.be.server.infra.order;
 
-import kr.hhplus.be.server.domain.order.event.OrderConfirmedEvent;
-import kr.hhplus.be.server.domain.order.event.OrderEventPublisher;
 import kr.hhplus.be.server.domain.order.OrderInfo;
+import kr.hhplus.be.server.domain.order.event.OrderConfirmedEvent;
+import kr.hhplus.be.server.domain.order.event.OrderEvent;
+import kr.hhplus.be.server.domain.order.event.OrderEventPublisher;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
@@ -16,6 +17,11 @@ public class OrderEventSpringPublisher implements OrderEventPublisher {
     @Override
     public void publishOrderConfirmed(OrderInfo orderInfo) {
         eventPublisher.publishEvent(new OrderConfirmedEvent(orderInfo));
+    }
+
+    @Override
+    public void publishOrderConfirmedEvent(OrderInfo orderInfo) {
+        eventPublisher.publishEvent(new OrderEvent.Confirmed(orderInfo));
     }
 }
 


### PR DESCRIPTION
### **커밋 링크**

이벤트 클래스 구조 통합 수정: 6b990d65ef6b34849f345a76af9a650b10bb28ae

- 기존 단독 클래스였던 OrderConfirmedEvent를 OrderEvent 내부 static 클래스 Confirmed로 주문 확정 이벤트 일원화
- 퍼블리셔·리스너·테스트 전부 `OrderEvent.Confirmed` 타입으로 교체

<!-- 
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.


필수 양식)
커밋 이름 : 커밋 링크

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->

---

과제를 제출하고 고민해보니, 현재구조에서는 이벤트가 추가되면 클래스 및 리스너가 계속해서 추가되는 구조인데

이렇게 크게 OrderEvent 클래스 안에 inner static 으로 처리하면 유지보수에 더 좋을거같다고 생각했습니다
```java
public class OrderEvent {

    // 이번에 구현한 주문 확정 이벤트를 inner class로 옮긴 모습
    @Getter
    public static class OrderConfirmed {

        private final OrderInfo orderInfo;

        public OrderConfirmed(OrderInfo orderInfo) {
            this.orderInfo = orderInfo;
        }
    }

   // 만약 주문 취소 이벤트를 만들어야한다면 이런식으로 추가가 됩니다
    @Getter
    public static class OrderCanceled {

        private final OrderInfo orderInfo;

        public OrderCanceled(OrderInfo orderInfo) {
            this.orderInfo = orderInfo;
        }
    }
}
```
추가로 리스너의 경우에도 OrderDataPlatformEventListener, ProductSalesEventListener 이렇게 각각의 클래스로 나누기보단
하나의 클래스안에서 두개모두 작성하면 더 컨트롤하기 좋을거라고 생각했습니다
```java
@Slf4j
@Component
@RequiredArgsConstructor
public class OrderEventListener {

    private final OrderDataPlatformClient orderDataPlatformClient;
    private final ProductSalesService productSalesService;

    @Async
    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
    public void sendToDataPlatform(OrderEvent.OrderConfirmed event) {
        try {
            orderDataPlatformClient.sendOrderData(event.getOrderInfo());
            log.info("데이터 플랫폼에 주문 데이터 전송 완료");

        } catch (Exception e) {
            log.info("데이터 플랫폼에 주문 데이터 전송 실패");
        }
    }

    @Async
    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
    public void storeProductSalesToRedis(OrderEvent.OrderConfirmed event) {
        try {
            productSalesService.add(event.getOrderInfo().orderItems());
            log.info("상품 판매량 기록 완료");

        } catch (Exception e) {
            log.info("상품 판매량 기록 실패");
        }
    }
}
```
이 경우에는 주문 취소 이벤트나 주문 00 이벤트를 처리하려는 리스너가 생기면 오히려 길어질거같아서 이부분은 OrderEventListener가 아닌 OrderConfirmedEventListener, OrderCanceledEventListener로 가면 좋을거같다고 생각했습니다

이렇게하면 클래스 관리하기 더 좋다고 생각합니다

테스트 코드 성공 - 로그
<img width="1313" alt="image" src="https://github.com/user-attachments/assets/7a9cf3f9-c927-4eb5-b2b5-ca3e4ac355b7" />


