### PR TITLE
심화과제: 카프카를 활용하여 쿠폰 발급 비즈니스 프로세스 개선 

### DIFF
--- a/docs/Kafka_Apply.md
+++ b/docs/Kafka_Apply.md
@@ -1,0 +1,58 @@
+# Apache Kafka 적용
+
+##  선착순 쿠폰 발급
+
+### 1. 변경 전 (Redis 기반)
+> ZADD NX으로 중복 신청 차단하고, score = time로 신청 순서 보장하며, 10 분 내 확정함으로써 메모리·폭주 트래픽 최소화한다.  
+> 대규모로 들어오는 선착순 쿠폰이라 이정도로 설정해도 많이 몰릴 것으로 판단하여 TTL을 10분으로 설정하였다.
+
+```mermaid
+graph LR
+%% ---------- 실시간 단계 ----------
+    subgraph "① 실시간 대기열"
+        U[User] --> CAPI["쿠폰 발급 신청 API"]
+        CAPI -- "ZADD NX, EXPIRE 600" --> ZQ["Redis ZSET\n(candidates:coupon:{id})"]
+    end
+
+%% ---------- 자정 배치 ----------
+    subgraph "② 자정 배치 확정 (00:00 KST)"
+        ZQ -- "ZRANGE N, ZREM" --> SCH["Scheduler\n(@Scheduled)"]
+        SCH -- "유저 쿠폰 저장" --> UC["MySQL user_coupon"]
+        SCH -- "발급 가능 쿠폰 차감" --> CP["MySQL coupon"]
+    end
+```
+
+### 2. 변경 후 (Kafka 기반)
+
+> Redis 대기열을 **Kafka Topic `coupon-issue-req`** 로 교체한다.  
+> • 순서 보장(키=`couponId`) • 내구성 • Consumer 수평 확장 • TTL 불필요
+
+```mermaid
+graph LR
+    %% ---------- 실시간 단계 ----------
+    subgraph "① 실시간 요청"
+        U[User] --> CAPI["쿠폰 발급 신청 API"]
+        CAPI -- "produce(key=couponId)" --> KQ["Kafka Topic\ncoupon-issue-req"]
+    end
+
+    %% ---------- Consumer 처리 ----------
+    subgraph "② Consumer 처리 (즉시)"
+        KQ --> CON["CouponIssueConsumer\n(@KafkaListener)"]
+        CON -- "재고 차감 & UserCoupon 저장" --> DB["MySQL coupon / user_coupon"]
+    end
+```
+
+#### 핵심 변화
+1. **ZSET + Scheduler 제거** → 메시지 발행 직후 Consumer 가 실시간 처리  
+2. **Kafka 파티셔닝**  
+   *  같은 `couponId` 는 동일 파티션에 기록되어 **재고 race condition 없음**   
+3. **모니터링/리플레이**  
+   *  Topic 로그 그대로 보존 ⇒ 장애 시 특정 offset 부터 재처리 가능
+
+#### 결론
+| 항목 | Redis 방식 | Kafka 방식 |
+|------|-----------|-----------|
+| 순서 보장 | ZSET `score=time` | 파티션 단일 리더 |
+| 대량 유입 내구성 | 메모리 기반, TTL 필요 | 디스크 로그, Retention 정책 |
+| 수평 확장 | Scheduler 단일 인스턴스 | Consumer Group 로드밸런싱 |
+| 리플레이/분석 | 수동 백업 필요 | offset 이동으로 즉시 가능 |

--- a/docs/Kafka_Apply.md
+++ b/docs/Kafka_Apply.md
@@ -11,12 +11,14 @@ graph LR
 %% ---------- 실시간 단계 ----------
     subgraph "① 실시간 대기열"
         U[User] --> CAPI["쿠폰 발급 신청 API"]
-        CAPI -- "ZADD NX, EXPIRE 600" --> ZQ["Redis ZSET\n(candidates:coupon:{id})"]
+        CAPI -- "ZADD NX, EXPIRE 600" --> ZQ["Redis ZSET
+                                            (candidates:coupon:{id})"]
     end
 
 %% ---------- 자정 배치 ----------
     subgraph "② 자정 배치 확정 (00:00 KST)"
-        ZQ -- "ZRANGE N, ZREM" --> SCH["Scheduler\n(@Scheduled)"]
+        ZQ -- "ZRANGE N, ZREM" --> SCH["Scheduler
+                                        (@Scheduled)"]
         SCH -- "유저 쿠폰 저장" --> UC["MySQL user_coupon"]
         SCH -- "발급 가능 쿠폰 차감" --> CP["MySQL coupon"]
     end
@@ -32,12 +34,14 @@ graph LR
     %% ---------- 실시간 단계 ----------
     subgraph "① 실시간 요청"
         U[User] --> CAPI["쿠폰 발급 신청 API"]
-        CAPI -- "produce(key=couponId)" --> KQ["Kafka Topic\ncoupon-issue-req"]
+        CAPI -- "produce(key=couponId)" --> KQ["Kafka Topic
+                                                 coupon-issue-req"]
     end
 
     %% ---------- Consumer 처리 ----------
     subgraph "② Consumer 처리 (즉시)"
-        KQ --> CON["CouponIssueConsumer\n(@KafkaListener)"]
+        KQ --> CON["CouponIssueConsumer
+                    (@KafkaListener)"]
         CON -- "재고 차감 & UserCoupon 저장" --> DB["MySQL coupon / user_coupon"]
     end
 ```

--- a/src/main/java/kr/hhplus/be/server/application/coupon/UserCouponFacade.java
+++ b/src/main/java/kr/hhplus/be/server/application/coupon/UserCouponFacade.java
@@ -6,6 +6,7 @@ import kr.hhplus.be.server.domain.coupon.CouponService;
 import kr.hhplus.be.server.domain.userCoupon.UserCouponCommand;
 import kr.hhplus.be.server.domain.userCoupon.UserCouponInfo;
 import kr.hhplus.be.server.domain.userCoupon.UserCouponService;
+import kr.hhplus.be.server.domain.userCoupon.event.CouponIssueProducer;
 import kr.hhplus.be.server.support.lock.DistributedLock;
 import kr.hhplus.be.server.support.lock.LockResource;
 import org.springframework.stereotype.Service;
@@ -19,10 +20,12 @@ public class UserCouponFacade {
 
     private final CouponService couponService;
     private final UserCouponService userCouponService;
+    private final CouponIssueProducer couponIssueProducer;
 
-    public UserCouponFacade(CouponService couponService, UserCouponService userCouponService) {
+    public UserCouponFacade(CouponService couponService, UserCouponService userCouponService, CouponIssueProducer couponIssueProducer) {
         this.couponService = couponService;
         this.userCouponService = userCouponService;
+        this.couponIssueProducer = couponIssueProducer;
     }
 
     @Transactional(readOnly = true)
@@ -62,6 +65,10 @@ public class UserCouponFacade {
             // 쿠폰 발행 처리
             couponService.updateIssuedCount(CouponCommand.Publish.of(pc.getCoupon(), pc.getQuantity()));
         }
+    }
+
+    public void issueCouponWithKafka(UserCouponCriteria.PublishRequest criteria) {
+        couponIssueProducer.send(criteria.getCouponId(), criteria.getUserId());
     }
 
 }

--- a/src/main/java/kr/hhplus/be/server/application/coupon/event/CouponIssueConsumer.java
+++ b/src/main/java/kr/hhplus/be/server/application/coupon/event/CouponIssueConsumer.java
@@ -1,0 +1,42 @@
+package kr.hhplus.be.server.application.coupon.event;
+
+import kr.hhplus.be.server.domain.coupon.CouponCommand;
+import kr.hhplus.be.server.domain.coupon.CouponInfo;
+import kr.hhplus.be.server.domain.coupon.CouponService;
+import kr.hhplus.be.server.domain.userCoupon.UserCouponCommand;
+import kr.hhplus.be.server.domain.userCoupon.UserCouponService;
+import kr.hhplus.be.server.domain.userCoupon.event.CouponIssueRequestEvent;
+import kr.hhplus.be.server.support.kafka.KafkaGroups;
+import kr.hhplus.be.server.support.kafka.KafkaTopics;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+public class CouponIssueConsumer {
+
+    private final CouponService couponService;
+    private final UserCouponService userCouponService;
+
+    public CouponIssueConsumer(CouponService couponService,
+                               UserCouponService userCouponService) {
+        this.couponService = couponService;
+        this.userCouponService = userCouponService;
+    }
+
+    @KafkaListener(topics = KafkaTopics.COUPON_ISSUE_REQUESTED, groupId = KafkaGroups.COUPON_CONSUMER)
+    @Transactional
+    public void listen(CouponIssueRequestEvent event, Acknowledgment ack) {
+        try {
+            CouponInfo.Issue issued = couponService.issueCoupon(CouponCommand.Issue.of(event.couponId(), event.userId()));
+            userCouponService.createUserCoupon(UserCouponCommand.of(issued.getCoupon(), event.userId()));
+
+            ack.acknowledge();
+        } catch (Exception ex) {
+            log.error("COUPON_ISSUE_REQUESTED 에러 발생: {}", ex.getMessage());
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/userCoupon/event/CouponIssueProducer.java
+++ b/src/main/java/kr/hhplus/be/server/domain/userCoupon/event/CouponIssueProducer.java
@@ -1,0 +1,19 @@
+package kr.hhplus.be.server.domain.userCoupon.event;
+
+import kr.hhplus.be.server.support.kafka.KafkaTopics;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CouponIssueProducer {
+
+    private final KafkaTemplate<String, Object> kafka;
+
+    public CouponIssueProducer(KafkaTemplate<String, Object> kafka) {
+        this.kafka = kafka;
+    }
+
+    public void send(Long couponId, Long userId) {
+        kafka.send(KafkaTopics.COUPON_ISSUE_REQUESTED, String.valueOf(couponId), new CouponIssueRequestEvent(couponId, userId));
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/userCoupon/event/CouponIssueRequestEvent.java
+++ b/src/main/java/kr/hhplus/be/server/domain/userCoupon/event/CouponIssueRequestEvent.java
@@ -1,0 +1,7 @@
+package kr.hhplus.be.server.domain.userCoupon.event;
+
+public record CouponIssueRequestEvent(
+        Long couponId,
+        Long userId
+) {
+}

--- a/src/main/java/kr/hhplus/be/server/support/kafka/KafkaGroups.java
+++ b/src/main/java/kr/hhplus/be/server/support/kafka/KafkaGroups.java
@@ -6,4 +6,5 @@ public final class KafkaGroups {
     }
 
     public static final String ORDER_CONSUMER = "order-consumer";
+    public static final String COUPON_CONSUMER = "coupon-issue-consumer";
 }

--- a/src/main/java/kr/hhplus/be/server/support/kafka/KafkaTopics.java
+++ b/src/main/java/kr/hhplus/be/server/support/kafka/KafkaTopics.java
@@ -5,5 +5,7 @@ public class KafkaTopics {
     private KafkaTopics() {
     }
 
-    public static final String ORDER_CONFIRMED = "order-confirmed-topic";
+    public static final String ORDER_CONFIRMED = "order-confirmed";
+    public static final String COUPON_ISSUE_REQUESTED = "coupon-issue-req";
+
 }

--- a/src/test/java/kr/hhplus/be/server/application/coupon/UserCouponFacadeKafkaItTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/coupon/UserCouponFacadeKafkaItTest.java
@@ -1,0 +1,101 @@
+package kr.hhplus.be.server.application.coupon;
+
+import kr.hhplus.be.server.domain.coupon.Coupon;
+import kr.hhplus.be.server.domain.coupon.CouponRepository;
+import kr.hhplus.be.server.domain.userCoupon.UserCouponRepository;
+import kr.hhplus.be.server.support.contanier.TestContainerSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class UserCouponFacadeKafkaItTest extends TestContainerSupport {
+
+    @Autowired
+    UserCouponFacade userCouponFacade;
+
+    @Autowired
+    CouponRepository couponRepository;
+
+    @Autowired
+    UserCouponRepository userCouponRepository;
+
+    Coupon coupon1;
+    Coupon coupon2;
+    Long userId1 = 123L;
+    Long userId2 = 456L;
+
+    @BeforeEach
+    void setUp() {
+        coupon1 = couponRepository.save(Coupon.createPercentage("TEST123", 10, 1, LocalDateTime.now().plusDays(1)));
+        coupon2 = couponRepository.save(Coupon.createPercentage("TEST123", 10, 2, LocalDateTime.now().plusDays(1)));
+        couponRepository.save(coupon1);
+        couponRepository.save(coupon2);
+    }
+
+    @Test
+    @DisplayName("쿠폰 발급 성공")
+    void issueCouponWithKafka_success() {
+        // given
+        var req = new UserCouponCriteria.PublishRequest(coupon1.getId(), userId1);
+
+        // when
+        userCouponFacade.issueCouponWithKafka(req);
+
+        // then
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(30))
+                .untilAsserted(() ->
+                        assertThat(userCouponRepository
+                                .existsByCouponIdAndUserId(coupon1.getId(), userId1))
+                                .isTrue());
+    }
+
+    @ExtendWith(OutputCaptureExtension.class)
+    @Test
+    @DisplayName("중복 발급시 이미 존재하는 쿠폰 에러 메세지 반환")
+    void duplicateIssueLogsError(CapturedOutput output) {
+        // given
+        var req = new UserCouponCriteria.PublishRequest(coupon2.getId(), userId1);
+
+        // when
+        userCouponFacade.issueCouponWithKafka(req);
+        userCouponFacade.issueCouponWithKafka(req);
+
+        // then
+        Awaitility.await().atMost(Duration.ofSeconds(30))
+                .untilAsserted(() ->
+                        assertThat(output)
+                                .contains("이미 존재하는 쿠폰"));
+    }
+
+    @ExtendWith(OutputCaptureExtension.class)
+    @Test
+    @DisplayName("매진된 쿠폰 발급 시 에러 로그 출력")
+    void soldOutIssueLogsError(CapturedOutput output) {
+        // given
+        var req1 = new UserCouponCriteria.PublishRequest(coupon1.getId(), userId1);
+        var req2 = new UserCouponCriteria.PublishRequest(coupon1.getId(), userId2); // 매진 이후 요청
+
+        // when
+        userCouponFacade.issueCouponWithKafka(req1);
+        userCouponFacade.issueCouponWithKafka(req2);
+
+        // then
+        Awaitility.await().atMost(Duration.ofSeconds(10))
+                .untilAsserted(() ->
+                        assertThat(output)
+                                .contains("더 이상 발급할 수 없습니다"));
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/application/coupon/event/CouponIssueConsumerTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/coupon/event/CouponIssueConsumerTest.java
@@ -1,0 +1,66 @@
+package kr.hhplus.be.server.application.coupon.event;
+
+import kr.hhplus.be.server.domain.coupon.Coupon;
+import kr.hhplus.be.server.domain.coupon.CouponCommand;
+import kr.hhplus.be.server.domain.coupon.CouponInfo;
+import kr.hhplus.be.server.domain.coupon.CouponService;
+import kr.hhplus.be.server.domain.userCoupon.UserCouponCommand;
+import kr.hhplus.be.server.domain.userCoupon.UserCouponService;
+import kr.hhplus.be.server.domain.userCoupon.event.CouponIssueRequestEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class CouponIssueConsumerTest {
+
+    @Mock
+    CouponService couponService;
+
+    @Mock
+    UserCouponService userCouponService;
+
+    CouponIssueConsumer consumer;
+
+    @BeforeEach
+    void setUp() {
+        consumer = new CouponIssueConsumer(couponService, userCouponService);
+    }
+
+    @Test
+    @DisplayName("쿠폰 발급 요청 이벤트를 처리한다")
+    void listen_CouponIssueRequestEvent() {
+        // given
+        Long couponId = 1L;
+        Long userId = 2L;
+
+        Coupon coupon = Coupon.builder().id(couponId).build();
+        CouponInfo.Issue issued = new CouponInfo.Issue(coupon);
+
+        Mockito.when(couponService.issueCoupon(Mockito.any(CouponCommand.Issue.class)))
+                .thenReturn(issued);
+
+        // when
+        org.springframework.kafka.support.Acknowledgment ack = Mockito.mock(org.springframework.kafka.support.Acknowledgment.class);
+        consumer.listen(new CouponIssueRequestEvent(couponId, userId), ack);
+
+        // then
+        ArgumentCaptor<UserCouponCommand> captor = ArgumentCaptor.forClass(UserCouponCommand.class);
+        Mockito.verify(userCouponService).createUserCoupon(captor.capture());
+
+        UserCouponCommand cmd = captor.getValue();
+        assertThat(cmd.coupon()).isEqualTo(coupon);
+        assertThat(cmd.userId()).isEqualTo(userId);
+
+        Mockito.verify(couponService)
+                .issueCoupon(Mockito.any(CouponCommand.Issue.class));
+        Mockito.verify(ack, Mockito.times(1)).acknowledge();
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/domain/userCoupon/event/CouponIssueProducerTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/userCoupon/event/CouponIssueProducerTest.java
@@ -1,0 +1,53 @@
+package kr.hhplus.be.server.domain.userCoupon.event;
+
+import kr.hhplus.be.server.support.kafka.KafkaTopics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class CouponIssueProducerTest {
+
+    @Mock
+    KafkaTemplate<String, Object> kafkaTemplate;
+
+    CouponIssueProducer producer;
+
+    @BeforeEach
+    void setUp() {
+        producer = new CouponIssueProducer(kafkaTemplate);
+    }
+
+    @Test
+    @DisplayName("카프카에 쿠폰 발급 요청 이벤트를 전송한다")
+    void send_CouponIssueRequestEvent() {
+        // given
+        Long couponId = 1L;
+        Long userId = 100L;
+
+        // when
+        producer.send(couponId, userId);
+
+        // then
+        ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Object> valueCaptor = ArgumentCaptor.forClass(Object.class);
+
+        verify(kafkaTemplate).send(eq(KafkaTopics.COUPON_ISSUE_REQUESTED), keyCaptor.capture(), valueCaptor.capture());
+
+        assertThat(keyCaptor.getValue()).isEqualTo(String.valueOf(couponId));
+        assertThat(valueCaptor.getValue()).isInstanceOf(CouponIssueRequestEvent.class);
+
+        CouponIssueRequestEvent event = (CouponIssueRequestEvent) valueCaptor.getValue();
+        assertThat(event.couponId()).isEqualTo(couponId);
+        assertThat(event.userId()).isEqualTo(userId);
+    }
+}


### PR DESCRIPTION
### **커밋 링크**
✅ 쿠폰 발급 처리 Producer, Consumer
- 구현: bc69a8913d15b7c997b36cdc9f7efd74c76eeb50
- 단위 테스트: 12eec0daf5dbbec3f0b602eac0392c4b5a3c6069

✅ 쿠폰 발급 비지니스 로직
- 구현: 4943fac5d478b115f8526774b53f5d95a36d3adf
- 통합테스트: 21958915128db2968aaeb8418380460f8a15e406

✅ 문서: 9fdab480c90cf5431600d76872f42d72c464e111  => [🔗 문서 바로가기](https://github.com/leevigong/hhplus-ecommerce/blob/week9/step18/docs/Kafka_Apply.md)

---
### **리뷰 포인트(질문)**
- 카프카 아직 크게 와닿진않지만 쿠폰 발급 로직을 레디스에서 카프카로 바꿔보면서 순차처리, 실시간이 보장되어서 합리적이라고 생각했습니다..! 


<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)
  
  좋은 예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->
---
### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->

### Problem
<!--개선이 필요한 점-->

### Try
<!-- 새롭게 시도할 점 -->
